### PR TITLE
Discounting RMST using an exponential discounting function

### DIFF
--- a/R/outputs.R
+++ b/R/outputs.R
@@ -60,6 +60,8 @@
 ##'
 ##' @param sample If \code{TRUE} then an MCMC sample is returned from the posterior
 ##' of the output, rather than summary statistics.
+##' @param disc_rate Discounting rate used to calculate the discounted RMST,
+##' using an exponential discounting function
 ##'
 ##' @param ... Other options (currently unused).
 ##'
@@ -72,10 +74,10 @@
 ##' @export
 mean.survextrap <- function(x, newdata=NULL,
                             newdata0=NULL, wane_period=NULL, wane_nt=10,
-                            niter=NULL, summ_fns=NULL, sample=FALSE, ...){
+                            niter=NULL, summ_fns=NULL, sample=FALSE, disc_rate = 0, ...){
   res <- rmst(x, t=Inf, newdata=newdata, niter=niter, summ_fns=summ_fns,
               newdata0=newdata0, wane_period=wane_period, wane_nt=wane_nt,
-              sample=sample)
+              sample=sample, disc_rate=disc_rate)
   res$variable <- "mean"
   res$t <- NULL
   res
@@ -110,7 +112,7 @@ mean.survextrap <- function(x, newdata=NULL,
 ##' @export
 rmst <- function(x,t,newdata=NULL,
                   newdata0=NULL, wane_period=NULL, wane_nt=10,
-                  niter=NULL,summ_fns=NULL,sample=FALSE){
+                  niter=NULL,summ_fns=NULL,sample=FALSE, disc_rate=0){
   newdata <- default_newdata(x, newdata)
   p <- prepare_pars(x=x, newdata=newdata, t=t, niter=niter, newdata0=newdata0, wane_period=wane_period)
 
@@ -128,7 +130,8 @@ rmst <- function(x,t,newdata=NULL,
                                        x$mspline$knots, x$mspline$degree,
                                        pcure = p$pcure[,,j],
                                        backhaz = backhaz,
-                                       bsmooth=x$mspline$bsmooth)
+                                       bsmooth=x$mspline$bsmooth,
+                                       disc_rate = disc_rate)
     else {
       coefs0 <- matrix(p$coefs0[,,j,], ncol=p$nvars)
       res_sam[,,j] <- rmst_survmspline_wane(t, alpha1 = p$alpha[,,j], alpha0 = p$alpha0[,,j],
@@ -139,7 +142,8 @@ rmst <- function(x,t,newdata=NULL,
                                             pcure0 = p$pcure0[,,j],
                                             backhaz = backhaz,
                                             bsmooth=x$mspline$bsmooth,
-                                            wane_period=wane_period, wane_nt=wane_nt
+                                            wane_period=wane_period, wane_nt=wane_nt,
+                                            disc_rate = disc_rate
                                             )
     }
   }
@@ -177,12 +181,12 @@ rmst <- function(x,t,newdata=NULL,
 ##'
 ##' @export
 irmst <- function(x, t, newdata=NULL, newdata0=NULL, wane_period=NULL, wane_nt=10,
-                  niter=NULL, summ_fns=NULL, sample=FALSE){
+                  niter=NULL, summ_fns=NULL, sample=FALSE, disc_rate = 0){
     newdata <- default_newdata_comparison(x, newdata)
     rmst1 <- rmst(x, t=t, newdata=newdata[1,,drop=FALSE], newdata0=newdata0[1,,drop=FALSE],
-                  wane_period = wane_period, wane_nt=wane_nt, niter=niter, sample=TRUE)
+                  wane_period = wane_period, wane_nt=wane_nt, niter=niter, sample=TRUE, disc_rate = disc_rate)
     rmst2 <- rmst(x, t=t, newdata=newdata[2,,drop=FALSE], newdata0=newdata0[2,,drop=FALSE],
-                  wane_period = wane_period, wane_nt=wane_nt, niter=niter, sample=TRUE)
+                  wane_period = wane_period, wane_nt=wane_nt, niter=niter, sample=TRUE, disc_rate = disc_rate)
     irmst_sam <- rmst2 - rmst1
     res <- summarise_output(irmst_sam, summ_fns, t, newdata=NULL,
                             summ_name="irmst", sample=sample)
@@ -333,7 +337,7 @@ cumhaz <- function(x, newdata=NULL, t=NULL, tmax=NULL,
 #' Or if \code{sample=TRUE}, an array with dimensions
 #' \code{length(t)}, \code{niter}, and 1, giving the
 #' incremental RMST evaluated at different times and MCMC iterations
-#' respectively. 
+#' respectively.
 #'
 #' @export
 hazard_ratio <- function(x, newdata=NULL, t=NULL, tmax=NULL, niter=NULL, summ_fns=NULL, sample=FALSE) {
@@ -365,7 +369,7 @@ hazard_ratio <- function(x, newdata=NULL, t=NULL, tmax=NULL, niter=NULL, summ_fn
 ##' Or if \code{sample=TRUE}, an array with dimensions
 ##' \code{1}, \code{niter}, and \code{nrow(newdata)}, giving the
 ##' incremental RMST evaluated at different MCMC iterations
-##' and covariate values respectively. 
+##' and covariate values respectively.
 ##'
 ##' @export
 hrtime <- function(x, newdata=NULL, niter=NULL, summ_fns=NULL, hq=c(0.1, 0.9), sample=FALSE){

--- a/R/survmspline.R
+++ b/R/survmspline.R
@@ -52,6 +52,9 @@
 ##'  \code{"time"} should be 0, and the final row specifies the hazard at all
 ##'  times greater than the last element of \code{"time"}.
 ##'
+##' @param disc_rate Discounting rate used to calculate the discounted RMST,
+##' using an exponential discounting function
+##'
 ##' @return \code{dsurvmspline} gives the density, \code{psurvmspline} gives the
 ##' distribution function, \code{hsurvmspline} gives the hazard and
 ##' \code{Hsurvmspline} gives the cumulative hazard.
@@ -284,12 +287,12 @@ validate_knots <- function(knots, name="knots"){
 
 ##' @rdname Survmspline
 ##' @export
-rmst_survmspline = function(t, alpha, coefs, knots, degree=3, pcure=0, offsetH=0, backhaz=NULL, bsmooth=TRUE){
+rmst_survmspline = function(t, alpha, coefs, knots, degree=3, pcure=0, offsetH=0, backhaz=NULL, bsmooth=TRUE, disc_rate = 0){
   if (is.null(pcure)) pcure <- 0
   rmst_generic(psurvmspline, t, start=0,
                matargs = c("coefs"),
                unvectorised_args = c("knots","degree","backhaz","bsmooth"),
-               alpha=alpha, coefs=coefs, knots=knots, degree=degree, pcure=pcure, offsetH=offsetH, backhaz=backhaz, bsmooth=bsmooth)
+               alpha=alpha, coefs=coefs, knots=knots, degree=degree, pcure=pcure, offsetH=offsetH, backhaz=backhaz, bsmooth=bsmooth, disc_rate=disc_rate)
 }
 
 ##' @rdname Survmspline
@@ -305,7 +308,7 @@ mean_survmspline = function(alpha, coefs, knots, degree=3, pcure=0, offsetH=0, b
 #
 # copied from flexsurv
 #
-rmst_generic <- function(pdist, t, start=0, matargs=NULL, unvectorised_args=NULL, ...)
+rmst_generic <- function(pdist, t, start=0, matargs=NULL, unvectorised_args=NULL, disc_rate = 0, ...)
 {
   args <- list(...)
   args_mat <- args[matargs]
@@ -321,6 +324,9 @@ rmst_generic <- function(pdist, t, start=0, matargs=NULL, unvectorised_args=NULL
       args[[i]] <- rep(args[[i]], length.out=maxlen)
       na_inds <- na_inds | is.na(args[[i]])
   }
+  # exponential discounting function
+  disc_fn <- function(t, disc_rate){ exp(-t*disc_rate)}
+
   t <- rep(t, length.out=maxlen)
   for (i in seq(along=args_mat)){
       if (is.matrix(args_mat[[i]])){
@@ -341,9 +347,9 @@ rmst_generic <- function(pdist, t, start=0, matargs=NULL, unvectorised_args=NULL
       pdargs <- c(list(start[i]), fargs_vec, fargs_mat, args_unvectorised)
       start_p <- 1 - do.call(pdist, pdargs)
       fn <- function(end){
-          pdargs <- c(list(end), fargs_vec, fargs_mat, args_unvectorised)
-          pd <- do.call(pdist, pdargs)
-          (1 - pd) / start_p
+        pdargs <- c(list(end), fargs_vec, fargs_mat, args_unvectorised)
+        pd <- do.call(pdist, pdargs)
+        (1 - pd)*disc_fn(end, disc_rate = disc_rate) / start_p
       }
       res <- try(integrate(fn, start[i], t[i]))
       if (!inherits(res, "try-error"))

--- a/man/Survmspline.Rd
+++ b/man/Survmspline.Rd
@@ -101,7 +101,8 @@ rmst_survmspline(
   pcure = 0,
   offsetH = 0,
   backhaz = NULL,
-  bsmooth = TRUE
+  bsmooth = TRUE,
+  disc_rate = 0
 )
 
 mean_survmspline(
@@ -161,6 +162,9 @@ also have zero derivative and second derivative at the boundary.}
 \item{p}{Vector of probabilities.}
 
 \item{n}{Number of random numbers to simulate.}
+
+\item{disc_rate}{Discounting rate used to calculate the discounted RMST,
+using an exponential discounting function}
 }
 \value{
 \code{dsurvmspline} gives the density, \code{psurvmspline} gives the

--- a/man/irmst.Rd
+++ b/man/irmst.Rd
@@ -13,7 +13,8 @@ irmst(
   wane_nt = 10,
   niter = NULL,
   summ_fns = NULL,
-  sample = FALSE
+  sample = FALSE,
+  disc_rate = 0
 )
 }
 \arguments{
@@ -53,6 +54,9 @@ output.}
 
 \item{sample}{If \code{TRUE} then an MCMC sample is returned from the posterior
 of the output, rather than summary statistics.}
+
+\item{disc_rate}{Discounting rate used to calculate the discounted RMST,
+using an exponential discounting function}
 }
 \value{
 A data frame (tibble) with each row containing posterior summary statistics

--- a/man/mean.survextrap.Rd
+++ b/man/mean.survextrap.Rd
@@ -13,6 +13,7 @@
   niter = NULL,
   summ_fns = NULL,
   sample = FALSE,
+  disc_rate = 0,
   ...
 )
 }
@@ -62,6 +63,9 @@ output.}
 
 \item{sample}{If \code{TRUE} then an MCMC sample is returned from the posterior
 of the output, rather than summary statistics.}
+
+\item{disc_rate}{Discounting rate used to calculate the discounted RMST,
+using an exponential discounting function}
 
 \item{...}{Other options (currently unused).}
 }

--- a/man/rmst.Rd
+++ b/man/rmst.Rd
@@ -13,7 +13,8 @@ rmst(
   wane_nt = 10,
   niter = NULL,
   summ_fns = NULL,
-  sample = FALSE
+  sample = FALSE,
+  disc_rate = 0
 )
 }
 \arguments{
@@ -65,6 +66,9 @@ output.}
 
 \item{sample}{If \code{TRUE} then an MCMC sample is returned from the posterior
 of the output, rather than summary statistics.}
+
+\item{disc_rate}{Discounting rate used to calculate the discounted RMST,
+using an exponential discounting function}
 }
 \value{
 A data frame (tibble) with each row containing posterior summary statistics


### PR DESCRIPTION
Hi Chris, 

We're interested in calculating discounted RMST for health economic analyses, so I've taken the liberty of trying to implement this within your survextrap `rmst()` and `irmst()` functions. 

It needs checking, but I believe it is doing the right thing. I haven't written any test function for it yet but have updated the documentation.

If you think this is useful, it could perhaps also be incorporated into flexsurv?